### PR TITLE
fix: :bug: fix transform to zone date in all formatters

### DIFF
--- a/src/modules/metrics/helpers/offering-comparative/comparative-offering-expenses-by-type-formatter.helper.ts
+++ b/src/modules/metrics/helpers/offering-comparative/comparative-offering-expenses-by-type-formatter.helper.ts
@@ -1,4 +1,5 @@
-import { addDays } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
+const timeZone = 'America/Lima';
 
 import { CurrencyType } from '@/modules/offering/shared/enums/currency-type.enum';
 import { OfferingExpense } from '@/modules/offering/expense/entities/offering-expense.entity';
@@ -43,13 +44,11 @@ export const comparativeOfferingExpensesByTypeFormatter = ({
 }: Options): OfferingExpenseComparativeByTypeDataResult[] => {
   const dataResult: OfferingExpenseComparativeByTypeDataResult[] =
     offeringExpenses?.reduce((acc, offering) => {
-      const offeringDate = new Date(addDays(offering.date, 1));
-      const offeringMonth = offeringDate.getMonth();
+      const zonedDate = toZonedTime(offering.date, timeZone);
+      const offeringMonth = zonedDate.getMonth();
 
       const existing = acc.find(
-        (item) =>
-          item?.month ===
-          monthNames[new Date(addDays(offering.date, 1)).getMonth()],
+        (item) => item?.month === monthNames[offeringMonth],
       );
 
       if (existing) {

--- a/src/modules/metrics/helpers/offering-comparative/comparative-offering-income-by-type-formatter.helper.ts
+++ b/src/modules/metrics/helpers/offering-comparative/comparative-offering-income-by-type-formatter.helper.ts
@@ -1,4 +1,5 @@
-import { addDays } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
+const timeZone = 'America/Lima';
 
 import { CurrencyType } from '@/modules/offering/shared/enums/currency-type.enum';
 
@@ -47,13 +48,11 @@ export const comparativeOfferingIncomeByTypeFormatter = ({
 }: Options): OfferingIncomeComparativeByTypeDataResult[] => {
   const dataResult: OfferingIncomeComparativeByTypeDataResult[] =
     offeringIncome?.reduce((acc, offering) => {
-      const offeringDate = new Date(addDays(offering.date, 1));
-      const offeringMonth = offeringDate.getMonth();
+      const zonedDate = toZonedTime(offering.date, timeZone);
+      const offeringMonth = zonedDate.getMonth();
 
       const existing = acc.find(
-        (item) =>
-          item?.month ===
-          monthNames[new Date(addDays(offering.date, 1)).getMonth()],
+        (item) => item?.month === monthNames[offeringMonth],
       );
 
       if (existing) {

--- a/src/modules/metrics/helpers/offering-comparative/income-and-expenses-comparative-formatter.helper.ts
+++ b/src/modules/metrics/helpers/offering-comparative/income-and-expenses-comparative-formatter.helper.ts
@@ -1,6 +1,6 @@
 import { toZonedTime } from 'date-fns-tz';
-
 const timeZone = 'America/Lima';
+
 import { OfferingIncome } from '@/modules/offering/income/entities/offering-income.entity';
 import { OfferingExpense } from '@/modules/offering/expense/entities/offering-expense.entity';
 import { OfferingIncomeCreationType } from '@/modules/offering/income/enums/offering-income-creation-type.enum';


### PR DESCRIPTION
Fix bug timestamps in all formaters in metrics offering comparatives.