### PR TITLE
refactor: :sparkles: add ministry member logic in sup pastor and copa…

### DIFF
--- a/src/common/enums/relation-type.enum.ts
+++ b/src/common/enums/relation-type.enum.ts
@@ -1,10 +1,12 @@
 export enum RelationType {
+  RelatedDirectToPastor = 'related_direct_pastor',
   OnlyRelatedHierarchicalCover = 'only_related_hierarchical_cover',
   OnlyRelatedMinistries = 'only_related_ministries',
   RelatedBothMinistriesAndHierarchicalCover = 'related_both_ministries_and_hierarchical_cover',
 }
 
 export const RelationTypeNames: Record<RelationType, string> = {
+  [RelationType.RelatedDirectToPastor]: 'Directa con pastor',
   [RelationType.OnlyRelatedHierarchicalCover]:
     'Solo con una cobertura jerárquica',
   [RelationType.OnlyRelatedMinistries]: 'Solo con ministerios',

--- a/src/common/helpers/create-ministry-member.ts
+++ b/src/common/helpers/create-ministry-member.ts
@@ -1,0 +1,56 @@
+import { Repository } from 'typeorm';
+import { BadRequestException } from '@nestjs/common';
+
+import { MinistryAssignment } from '@/common/interfaces/ministry-assignment.interface';
+
+import { User } from '@/modules/user/entities/user.entity';
+import { Member } from '@/modules/member/entities/member.entity';
+import { Ministry } from '@/modules/ministry/entities/ministry.entity';
+import { MinistryMember } from '@/modules/ministry/entities/ministry-member.entity';
+
+export interface Options {
+  theirMinistries: MinistryAssignment[];
+  ministryRepository: Repository<Ministry>;
+  ministryMemberRepository: Repository<MinistryMember>;
+  newMember: Member;
+  user: User;
+}
+
+export async function createMinistryMember({
+  theirMinistries,
+  ministryRepository,
+  ministryMemberRepository,
+  newMember,
+  user,
+}: Options): Promise<MinistryMember[]> {
+  const ministryMembers = await Promise.all(
+    theirMinistries.map(async (ministryData) => {
+      const ministry = await ministryRepository.findOne({
+        where: { id: ministryData.ministryId },
+      });
+
+      if (!ministry) {
+        throw new BadRequestException(
+          `El ministerio con ID ${ministryData.ministryId} no existe.`,
+        );
+      }
+
+      if (!ministry?.recordStatus) {
+        throw new BadRequestException(
+          `La propiedad "Estado de registro" en el Ministerio debe ser "Activo".`,
+        );
+      }
+
+      return ministryMemberRepository.create({
+        member: newMember,
+        memberRoles: newMember.roles,
+        ministryRoles: ministryData.ministryRoles,
+        ministry,
+        createdAt: new Date(),
+        createdBy: user,
+      });
+    }),
+  );
+
+  return await ministryMemberRepository.save(ministryMembers);
+}

--- a/src/common/helpers/raise-level-ministry-member.ts
+++ b/src/common/helpers/raise-level-ministry-member.ts
@@ -1,0 +1,65 @@
+import { Repository } from 'typeorm';
+
+import { BadRequestException } from '@nestjs/common';
+import { MinistryAssignment } from '@/common/interfaces/ministry-assignment.interface';
+
+import { User } from '@/modules/user/entities/user.entity';
+import { Member } from '@/modules/member/entities/member.entity';
+import { Ministry } from '@/modules/ministry/entities/ministry.entity';
+import { MinistryMember } from '@/modules/ministry/entities/ministry-member.entity';
+
+export interface Options {
+  theirMinistries: MinistryAssignment[];
+  ministryRepository: Repository<Ministry>;
+  ministryMemberRepository: Repository<MinistryMember>;
+  savedMember: Member;
+  user: User;
+}
+
+export async function raiseLevelMinistryMember({
+  theirMinistries,
+  savedMember,
+  ministryRepository,
+  ministryMemberRepository,
+  user,
+}: Options): Promise<MinistryMember[]> {
+  const ministryMembers = await Promise.all(
+    theirMinistries.map(async (ministryData) => {
+      const ministry = await ministryRepository.findOne({
+        where: { id: ministryData?.ministryId },
+      });
+
+      if (!ministry?.recordStatus) {
+        throw new BadRequestException(
+          `La propiedad "Estado de registro" en el Ministerio debe ser "Activo".`,
+        );
+      }
+
+      const existingMember = await ministryMemberRepository.findOne({
+        where: {
+          member: { id: savedMember.id },
+          ministry: { id: ministry.id },
+        },
+      });
+
+      if (existingMember) {
+        existingMember.ministryRoles = ministryData.ministryRoles;
+        existingMember.memberRoles = savedMember.roles;
+        existingMember.updatedAt = new Date();
+        existingMember.updatedBy = user;
+        return existingMember;
+      }
+
+      return ministryMemberRepository.create({
+        member: savedMember,
+        memberRoles: savedMember.roles,
+        ministryRoles: ministryData.ministryRoles,
+        ministry: ministry,
+        createdAt: new Date(),
+        createdBy: user,
+      });
+    }),
+  );
+
+  return await ministryMemberRepository.save(ministryMembers.filter(Boolean));
+}

--- a/src/common/helpers/update-ministry-member.ts
+++ b/src/common/helpers/update-ministry-member.ts
@@ -1,0 +1,81 @@
+import { Repository } from 'typeorm';
+
+import { BadRequestException } from '@nestjs/common';
+import { MinistryAssignment } from '@/common/interfaces/ministry-assignment.interface';
+
+import { User } from '@/modules/user/entities/user.entity';
+import { Member } from '@/modules/member/entities/member.entity';
+import { Ministry } from '@/modules/ministry/entities/ministry.entity';
+import { MinistryMember } from '@/modules/ministry/entities/ministry-member.entity';
+
+export interface Options {
+  theirMinistries: MinistryAssignment[];
+  ministryRepository: Repository<Ministry>;
+  ministryMemberRepository: Repository<MinistryMember>;
+  savedMember: Member;
+  user: User;
+}
+
+export async function updateMinistryMember({
+  theirMinistries,
+  savedMember,
+  ministryRepository,
+  ministryMemberRepository,
+  user,
+}: Options): Promise<MinistryMember[]> {
+  const currentMinistryMembers: MinistryMember[] =
+    await ministryMemberRepository.find({
+      where: { member: { id: savedMember.id } },
+      relations: ['ministry'],
+    });
+
+  const newMinistryIds = theirMinistries.map((m) => m.ministryId);
+
+  const toRemove = currentMinistryMembers.filter(
+    (ministryMember) => !newMinistryIds.includes(ministryMember.ministry.id),
+  );
+
+  if (toRemove.length > 0) {
+    await ministryMemberRepository.remove(toRemove);
+  }
+
+  const ministryMembers: MinistryMember[] = await Promise.all(
+    theirMinistries.map(async (ministryData) => {
+      const ministry = await ministryRepository.findOne({
+        where: { id: ministryData?.ministryId },
+      });
+
+      if (!ministry?.recordStatus) {
+        throw new BadRequestException(
+          `La propiedad "Estado de registro" en el Ministerio debe ser "Activo".`,
+        );
+      }
+
+      const existingMember: MinistryMember =
+        await ministryMemberRepository.findOne({
+          where: {
+            member: { id: savedMember.id },
+            ministry: { id: ministry.id },
+          },
+        });
+
+      if (existingMember) {
+        existingMember.ministryRoles = ministryData.ministryRoles;
+        existingMember.updatedAt = new Date();
+        existingMember.updatedBy = user;
+        return existingMember;
+      }
+
+      return ministryMemberRepository.create({
+        member: savedMember,
+        memberRoles: savedMember.roles,
+        ministryRoles: ministryData.ministryRoles,
+        ministry: ministry,
+        createdAt: new Date(),
+        createdBy: user,
+      });
+    }),
+  );
+
+  return await ministryMemberRepository.save(ministryMembers.filter(Boolean));
+}

--- a/src/common/helpers/validation-exists-changes-ministry-member.ts
+++ b/src/common/helpers/validation-exists-changes-ministry-member.ts
@@ -1,0 +1,40 @@
+import { Pastor } from '@/modules/pastor/entities/pastor.entity';
+import { Disciple } from '@/modules/disciple/entities/disciple.entity';
+import { Preacher } from '@/modules/preacher/entities/preacher.entity';
+import { Copastor } from '@/modules/copastor/entities/copastor.entity';
+import { Supervisor } from '@/modules/supervisor/entities/supervisor.entity';
+
+import { MinistryAssignment } from '@/common/interfaces/ministry-assignment.interface';
+
+export interface Options {
+  theirMinistries: MinistryAssignment[];
+  memberEntity: Disciple | Preacher | Supervisor | Copastor | Pastor;
+}
+
+export function validationExistsChangesMinistryMember({
+  theirMinistries,
+  memberEntity,
+}: Options): boolean {
+  const existingMinistryIds =
+    memberEntity.member?.ministries?.map((m) => m.ministry.id) ?? [];
+  const newMinistryIds = theirMinistries.map((m) => m.ministryId);
+
+  const hasChangesInMinistries =
+    theirMinistries.some((newMinistry) => {
+      const existing = memberEntity.member?.ministries?.find(
+        (m) => m.ministry.id === newMinistry.ministryId,
+      );
+
+      if (!existing) return true;
+
+      const existingRoles = [...existing.ministryRoles].sort();
+      const newRoles = [...newMinistry.ministryRoles].sort();
+
+      return (
+        existingRoles.length !== newRoles.length ||
+        existingRoles.some((role, idx) => role !== newRoles[idx])
+      );
+    }) || existingMinistryIds.some((id) => !newMinistryIds.includes(id));
+
+  return hasChangesInMinistries;
+}

--- a/src/modules/copastor/dto/create-copastor.dto.ts
+++ b/src/modules/copastor/dto/create-copastor.dto.ts
@@ -21,6 +21,8 @@ import { MaritalStatus } from '@/common/enums/marital-status.enum';
 import { MemberInactivationReason } from '@/common/enums/member-inactivation-reason.enum';
 import { MemberInactivationCategory } from '@/common/enums/member-inactivation-category.enum';
 
+import { MinistryAssignment } from '@/common/interfaces/ministry-assignment.interface';
+
 export class CreateCopastorDto {
   //* General and Personal info
   @ApiProperty({
@@ -216,6 +218,21 @@ export class CreateCopastorDto {
   @IsString()
   @IsOptional()
   theirChurch?: string;
+
+  @ApiProperty({
+    description:
+      'Listado de ministerios asignados a la persona (discípulo, pastor, predicador, etc.) junto con sus roles dentro de cada ministerio.',
+    example: [
+      {
+        ministryId: '1234567890abcdef2sfs24021a',
+        ministryRoles: ['kids_ministry_leader', 'youth_ministry_member'],
+      },
+    ],
+    required: false,
+  })
+  @IsArray()
+  @IsOptional()
+  theirMinistries?: MinistryAssignment[];
 
   //! Properties record inactivation (optional)
   @IsOptional()

--- a/src/modules/pastor/dto/create-pastor.dto.ts
+++ b/src/modules/pastor/dto/create-pastor.dto.ts
@@ -21,6 +21,8 @@ import { MaritalStatus } from '@/common/enums/marital-status.enum';
 import { MemberInactivationReason } from '@/common/enums/member-inactivation-reason.enum';
 import { MemberInactivationCategory } from '@/common/enums/member-inactivation-category.enum';
 
+import { MinistryAssignment } from '@/common/interfaces/ministry-assignment.interface';
+
 export class CreatePastorDto {
   //* General and Personal info
   @ApiProperty({
@@ -208,6 +210,21 @@ export class CreatePastorDto {
   @IsString()
   @IsOptional()
   theirChurch?: string;
+
+  @ApiProperty({
+    description:
+      'Listado de ministerios asignados a la persona (discípulo, pastor, predicador, etc.) junto con sus roles dentro de cada ministerio.',
+    example: [
+      {
+        ministryId: '1234567890abcdef2sfs24021a',
+        ministryRoles: ['kids_ministry_leader', 'youth_ministry_member'],
+      },
+    ],
+    required: false,
+  })
+  @IsArray()
+  @IsOptional()
+  theirMinistries?: MinistryAssignment[];
 
   //! Properties record inactivation (optional)
   @IsOptional()

--- a/src/modules/supervisor/dto/create-supervisor.dto.ts
+++ b/src/modules/supervisor/dto/create-supervisor.dto.ts
@@ -3,7 +3,7 @@ import {
   IsEmail,
   IsArray,
   IsString,
-  IsBoolean,
+  // IsBoolean,
   MaxLength,
   MinLength,
   IsNotEmpty,
@@ -19,6 +19,7 @@ import { Gender } from '@/common/enums/gender.enum';
 import { MemberRole } from '@/common/enums/member-role.enum';
 import { RecordStatus } from '@/common/enums/record-status.enum';
 import { MaritalStatus } from '@/common/enums/marital-status.enum';
+import { MinistryAssignment } from '@/common/interfaces/ministry-assignment.interface';
 import { MemberInactivationReason } from '@/common/enums/member-inactivation-reason.enum';
 import { MemberInactivationCategory } from '@/common/enums/member-inactivation-category.enum';
 
@@ -203,11 +204,11 @@ export class CreateSupervisorDto {
   @IsOptional()
   recordStatus?: string;
 
-  @ApiProperty({
-    example: true,
-  })
-  @IsBoolean()
-  isDirectRelationToPastor: boolean;
+  // @ApiProperty({
+  //   example: true,
+  // })
+  // @IsBoolean()
+  // isDirectRelationToPastor: boolean;
 
   //* Relations
   @ApiProperty({
@@ -223,6 +224,35 @@ export class CreateSupervisorDto {
   @IsString()
   @IsOptional()
   theirPastor?: string;
+
+  @ApiProperty({
+    example: 'cf5a9ee3-cad7-4b73-a331-a5f3f76f6661',
+  })
+  @IsString()
+  @IsOptional()
+  theirPastorRelationDirect?: string;
+
+  @ApiProperty({
+    example: 'cf5a9ee3-cad7-4b73-a331-a5f3f76f6661',
+  })
+  @IsString()
+  @IsOptional()
+  theirPastorOnlyMinistries?: string;
+
+  @ApiProperty({
+    description:
+      'Listado de ministerios asignados a la persona (discípulo, pastor, predicador, etc.) junto con sus roles dentro de cada ministerio.',
+    example: [
+      {
+        ministryId: '1234567890abcdef2sfs24021a',
+        ministryRoles: ['kids_ministry_leader', 'youth_ministry_member'],
+      },
+    ],
+    required: false,
+  })
+  @IsArray()
+  @IsOptional()
+  theirMinistries?: MinistryAssignment[];
 
   //! Properties record inactivation (optional)
   @IsOptional()


### PR DESCRIPTION
## Add Logic for Ministry Member Level Management

### Summary
This update adds and improves the logic for **creating**, **updating**, and **raising the ministry level** of members within the hierarchy of **Supervisor**, **Copastor**, and **Pastor**.

### Key Changes
- Added logic to **create and update ministry members** dynamically based on their current level.  
- Implemented functionality to **promote members** across ministry levels:  
  - Supervisor → Copastor  
  - Copastor → Pastor  
- Introduced **helper functions** to simplify and centralize repeated logic.  
- **Refactored existing code** for better readability, structure, and maintainability.  
- Improved **error handling** and validations during promotions and updates.  

### Technical Improvements
- Created a dedicated **helper module** to manage ministry member creation and promotion logic.  
- Enhanced consistency in repository interactions (`create`, `update`, and `save`).  
- Reduced duplicated code through utility abstraction and clear function responsibilities.  

### Benefits
- Cleaner and more organized codebase.  
- Easier to maintain and extend future ministry-related logic.  
- Improved data consistency and error resilience during member level transitions.